### PR TITLE
Fix typo in deb package definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ release = "1.el8"
 copyright = "2021, Frits Hoogland <fhoogland@yugabyte.com>"
 maintainer = "Frits Hoogland <fhoogland@yugabyte.com>"
 assets = [
-    ["target/release/yb_stats", "/usr/local/bin", "755"]
+    ["target/release/yb_stats", "/usr/local/bin/", "755"]
 ]


### PR DESCRIPTION
Fixes #4 

The Ubuntu 22.04 deb package definition incorrectly writes yb_stats as a file called /usr/local/bin instead of placing it in the directory /usr/local/bin. This commit corrects the typo that causes this issue.